### PR TITLE
Add NVMe EBS support

### DIFF
--- a/recipes/ebs.rb
+++ b/recipes/ebs.rb
@@ -23,26 +23,46 @@ unless iam_profile_instance?
   creds = data_bag_item('secrets', 'aws_credentials')['Storage']
 end
 
-if nvme_instance?
-  log 'Due to how EC2 supports EBS volumes on some NVMe instances, we cannot mount them at this time.'
-else
-  node['storage']['ebs_volumes'].each_with_index do |(name, conf), i|
-    aws_ebs_volume name do
-      conf.each { |key, value| send(key, value) }
-      if creds
-        aws_access_key creds['access_key_id']
-        aws_secret_access_key creds['secret_access_key']
-      end
-      action %i(create attach)
+node['storage']['ebs_volumes'].each_with_index do |(name, conf), i|
+  aws_ebs_volume name do
+    conf.each { |key, value| send(key, value) }
+    if creds
+      aws_access_key creds['access_key_id']
+      aws_secret_access_key creds['secret_access_key']
     end
-
-    mount_point = "/mnt/ebs#{i}"
-    device_name = conf['device']
-
-    storage_format_mount mount_point do
-      device_name device_name
-    end
-
-    node.normal['storage']['ebs_mounts'] = (node['storage']['ebs_mounts'] || []) | [mount_point]
+    action %i(create attach)
   end
+
+  mount_point = "/mnt/ebs#{i}"
+  device_name = if nvme_instance?
+                  if node['storage'].attribute?('ebs_mounts') &&
+                     node['storage']['ebs_mounts'].include?('mount_point')
+                    Chef::Log.info "#{mount_point} already mounted."
+                    node['filesystem']['by_mountpoint'][mount_point]['devices'].first
+                  else
+                    if node['filesystem']['by_device'].keys.length > 10
+                      log 'Greater than 10 devices detected, sorting may not work properly'
+                    end
+
+                    # Get the list of filesystem devices, sort them in order,
+                    # grab the last one, and increment the device number.
+                    # This ensures that any EBS volumes are assigned an open device number.
+                    #
+                    # Per the above log resource, > 10 devices means sort will not work
+                    # properly b/c 10 comes before 2 when sorting strings.
+                    node['filesystem']['by_device'].keys.grep(%r{/dev/nvme}).sort.last
+                                                   .gsub(/nvme([1-9]|1[0-9]|2[0-6])n1/) do |_m|
+                                                     "nvme#{Regexp.last_match(1).to_i + i + 1}n1"
+                                                   end
+                  end
+                else
+                  Chef::Log.info "Mounting the user supplied #{conf['device']} to #{mount_point}."
+                  conf['device']
+                end
+
+  storage_format_mount mount_point do
+    device_name device_name
+  end
+
+  node.normal['storage']['ebs_mounts'] = (node['storage']['ebs_mounts'] || []) | [mount_point]
 end

--- a/test/integration/nvme-c5d/default_spec.rb
+++ b/test/integration/nvme-c5d/default_spec.rb
@@ -9,6 +9,12 @@ describe mount '/mnt/dev0' do
   its('options') { should eq ['rw', 'relatime', 'data=ordered'] }
 end
 
+describe mount '/mnt/ebs0' do
+  its('device') { should eq '/dev/nvme2n1' }
+  its('type') { should eq 'ext4' }
+  its('options') { should eq ['rw', 'relatime', 'data=ordered'] }
+end
+
 describe mount '/mnt' do
   it { should_not be_mounted }
 end


### PR DESCRIPTION
See [the docs for details](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html)

We test this with the `c5d` class, which is EBS-backed for its root volume, and has one additional ephemeral instance storage device.